### PR TITLE
Fixed ProgramDesc padding

### DIFF
--- a/styles/components/sections/ProgramDesc.module.sass
+++ b/styles/components/sections/ProgramDesc.module.sass
@@ -1,2 +1,11 @@
+@use '@/styles/utils/mixin' as m
+
 .smallPl
   padding: 117px 290px 117px 215px
+  @include m.media(desktop, laptop)
+    padding: 100px 150px 100px 50px
+  @include m.media(laptop)
+    padding-right: 50px
+    padding-bottom: 220px
+  @include m.media(tablet, phone)
+    padding: 60px 10px 180px


### PR DESCRIPTION
This is a bugfix to an issue that I introduced by pull request #80: newly added class would overwrite small paddings on smaller screens.